### PR TITLE
debian: switch to native source format

### DIFF
--- a/debian/source/format
+++ b/debian/source/format
@@ -1,1 +1,1 @@
-3.0 (quilt)
+3.0 (native)


### PR DESCRIPTION
Force git-pbuilder to build the source tarball from current directory.